### PR TITLE
Pin docker base image to debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.2-fpm-stretch
 
 # Install tini (init handler)
 ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini


### PR DESCRIPTION
The PHP base images switched from stretch to buster and breaks the compatibility to
this Dockerfile. By pinning the PHP version to stretch we can build containers with this
Dockerfile.