### PR TITLE
TE-1070 Update search config

### DIFF
--- a/spryker/config_local.php.j2
+++ b/spryker/config_local.php.j2
@@ -12,6 +12,8 @@ use Spryker\Shared\ProductManagement\ProductManagementConstants;
 use Spryker\Shared\PropelQueryBuilder\PropelQueryBuilderConstants;
 use Spryker\Shared\Propel\PropelConstants;
 use Spryker\Shared\RabbitMq\RabbitMqEnv;
+use Spryker\Shared\Search\SearchConstants;
+use Spryker\Shared\SearchElasticsearch\SearchElasticsearchConstants;
 use Spryker\Shared\Scheduler\SchedulerConstants;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConfig;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConstants;
@@ -67,6 +69,16 @@ $ELASTICA_PARAMETER__EXTRA = [
 ];
 $config[ApplicationConstants::ELASTICA_PARAMETER__EXTRA] = $ELASTICA_PARAMETER__EXTRA;
 $config[SearchConstants::ELASTICA_PARAMETER__EXTRA] = $ELASTICA_PARAMETER__EXTRA;
+
+$config[SearchConstants::ELASTICA_PARAMETER__HOST]
+    = $config[SearchElasticsearchConstants::HOST] = getenv('ELASTICSEARCH_HOST');
+$config[SearchConstants::ELASTICA_PARAMETER__PORT]
+    = $config[SearchElasticsearchConstants::PORT] = getenv('ELASTICSEARCH_PORT');
+
+unset($config[SearchElasticsearchConstants::ELASTICA_PARAMETER__AUTH_HEADER]);
+
+$config[SearchConstants::ELASTICA_PARAMETER__EXTRA]
+    = $config[SearchElasticsearchConstants::EXTRA] = $ELASTICA_PARAMETER__EXTRA;
 
 // ---------- Scheduler
 $config[SchedulerConstants::ENABLED_SCHEDULERS] = [

--- a/spryker/config_local_nonsplit.php.j2
+++ b/spryker/config_local_nonsplit.php.j2
@@ -13,6 +13,8 @@ use Spryker\Shared\PropelQueryBuilder\PropelQueryBuilderConstants;
 use Spryker\Shared\Propel\PropelConstants;
 use Spryker\Shared\RabbitMq\RabbitMqEnv;
 use Spryker\Shared\Router\RouterConstants;
+use Spryker\Shared\Search\SearchConstants;
+use Spryker\Shared\SearchElasticsearch\SearchElasticsearchConstants;
 use Spryker\Shared\Scheduler\SchedulerConstants;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConfig;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConstants;
@@ -68,6 +70,16 @@ $ELASTICA_PARAMETER__EXTRA = [
 ];
 $config[ApplicationConstants::ELASTICA_PARAMETER__EXTRA] = $ELASTICA_PARAMETER__EXTRA;
 $config[SearchConstants::ELASTICA_PARAMETER__EXTRA] = $ELASTICA_PARAMETER__EXTRA;
+
+$config[SearchConstants::ELASTICA_PARAMETER__HOST]
+    = $config[SearchElasticsearchConstants::HOST] = getenv('ELASTICSEARCH_HOST');
+$config[SearchConstants::ELASTICA_PARAMETER__PORT]
+    = $config[SearchElasticsearchConstants::PORT] = getenv('ELASTICSEARCH_PORT');
+
+unset($config[SearchElasticsearchConstants::ELASTICA_PARAMETER__AUTH_HEADER]);
+
+$config[SearchConstants::ELASTICA_PARAMETER__EXTRA]
+    = $config[SearchElasticsearchConstants::EXTRA] = $ELASTICA_PARAMETER__EXTRA;
 
 // ---------- Scheduler
 $config[SchedulerConstants::ENABLED_SCHEDULERS] = [


### PR DESCRIPTION
Update of the search config.

Related to the release of https://spryker.atlassian.net/browse/TE-1070

It's using new constants, so it can't be used for deploy of old branches. Should I make it backwards compatible?